### PR TITLE
feat: Rename project to React Singleton Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 1.0.1 (2023-01-23)
 
-
 ### Continuous Integration
 
-* Skip husky removal for now during CI/CD ([3c53b1d](https://github.com/indeedeng/react-context-registry/commit/3c53b1d6cff2052ca2e1ebfb16564604cea8e898))
-
-# Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+-   Skip husky removal for now during CI/CD ([3c53b1d](https://github.com/indeedeng/react-singleton-context/commit/3c53b1d6cff2052ca2e1ebfb16564604cea8e898))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-To begin working on `react-context-registry`,
+To begin working on `react-singleton-context`,
 
 1. clone the repo and `cd` into the project directory
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# react-context-registry
+# react-singleton-context
 
 ## About
 
-React Context Registry is a small library to alleviate the pain points that come with using React Context in micro-frontend architectures.
+React Singleton Context is a small library to alleviate the pain points that come with using React Context in micro-frontend architectures.
 
 It is designed to be defined as a singleton, and it serves only one purpose: to offload the singleton requirements of React Context. This allows library maintainers to write their own modules, leverage context, and not have to worry about their own library being a singleton.
 
 ### How do I know if I need it?
 
-If you have all three aspects below, chances are you'll want to use React Context Registry:
+If you have all three aspects below, chances are you'll want to use React Singleton Context:
 
 -   A host application / platform which employs [Webpack's Module Federation](https://webpack.js.org/concepts/module-federation/).
 -   A JavaScript / TypeScript library which employs React Context.
@@ -21,24 +21,24 @@ But singletonization of the library, in solving one problem, creates another: th
 So you're presented with two options:
 
 1. Keep all entry points constantly up-to-date with the latest version of the singletonized library.
-2. Use React Context Registry.
+2. Use React Singleton Context.
 
 Option 1 is operationally expensive. Option 2, we outline below.
 
-## How to use React Context Registry
+## How to use React Singleton Context
 
-### 1. Install React Context Registry into the host application
+### 1. Install React Singleton Context into the host application
 
 First, add the package as a dependency, like so:
 
 ```
-npm install react-context-registry
+npm install react-singleton-context
 ```
 
 or, if using Yarn:
 
 ```
-yarn add react-context-registry
+yarn add react-singleton-context
 ```
 
 Once that's done, go ahead and add it as an eager singleton to your Webpack config's Module Federation plugin declaration:
@@ -48,7 +48,7 @@ Once that's done, go ahead and add it as an eager singleton to your Webpack conf
 		...
 		shared: {
 			...
-  			'react-context-registry': { singleton: true, eager: true },
+  			'react-singleton-context': { singleton: true, eager: true },
 			...
 		}
 ```
@@ -58,31 +58,31 @@ You'll also want to import the context registry into whatever bootstrapping code
 Something like this will suffice:
 
 ```typescript
-import 'react-context-registry';
+import 'react-singleton-context';
 ```
 
 Remember, your host application's setup might differ slightly from the above, so refer to your host application's owning team for exact details, if necessary.
 
-### 2. Install React Context Registry into any build-time library dependencies federated applications use
+### 2. Install React Singleton Context into any build-time library dependencies federated applications use
 
 Like you did with the host application, it's time to add the package to the library:
 
 ```
-npm install react-context-registry --save-dev
+npm install react-singleton-context --save-dev
 ```
 
 or, if using Yarn:
 
 ```
-yarn add react-context-registry --dev
+yarn add react-singleton-context --dev
 ```
 
-Then, add `react-context-registry` as a `peerDependency` for this library, too. Doing so will necessitate a major version bump for your library, as that's a breaking change.
+Then, add `react-singleton-context` as a `peerDependency` for this library, too. Doing so will necessitate a major version bump for your library, as that's a breaking change.
 
 The following is example usage that a library maintainer might employ in the actual application code.
 
 ```typescript
-import { createRegisteredContext } from 'react-context-registry';
+import { createRegisteredContext } from 'react-singleton-context';
 
 interface IExampleContext {
     message: string;
@@ -101,7 +101,7 @@ export default ExampleContext;
 or, if not using TypeScript:
 
 ```javascript
-import { createRegisteredContext } from 'react-context-registry';
+import { createRegisteredContext } from 'react-singleton-context';
 
 // Create the React.Context with createRegisteredContext instead of React.createContext
 const ExampleContext = createRegisteredContext(
@@ -117,6 +117,6 @@ export default ExampleContext;
 
 Now that your platform and your library are ready, it's time to update the federated application's dependencies to leverage the latest and greatest.
 
-Optionally, if your library was previously singletonized (because you weren't able to use React Context Registry previously to get around the context problem), you can safely de-singletonize it in the same commit.
+Optionally, if your library was previously singletonized (because you weren't able to use React Singleton Context previously to get around the context problem), you can safely de-singletonize it in the same commit.
 
 And that's it! You're now using singletonized context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "react-context-registry",
+    "name": "react-singleton-context",
     "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "react-context-registry",
+    "name": "react-singleton-context",
     "version": "1.0.1",
     "description": "A small library designed to register and return singletonized React contexts",
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/indeedeng/react-context-registry"
+        "url": "https://github.com/indeedeng/react-singleton-context"
     },
     "files": [
         "dist",


### PR DESCRIPTION
For better clarity of purpose, we renamed the project and package

BREAKING CHANGE: The package is now called react-singleton-context and must be installed accordingly