### PR TITLE
Ensure husky is skipped during GitHub Action runs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,12 +18,12 @@ jobs:
           git config user.email "github-actions-bot@users.noreply.github.com"
       - name: Install npm dependencies
         run: npm ci
+        env:
+          HUSKY: 0
       - name: Run quality checks
         run: npm run quality
       - name: Build project
         run: npm run build
-      # - name: Prevent husky from interfering with standard-version commit
-      #   run: rm ./.git/hooks/prepare-commit-msg
       - name: Run standard-version to bump version
         run: npm run release
       - name: Push version bump to main


### PR DESCRIPTION
Simple fix to our GitHub Actions flow, leveraging the `HUSKY=0` env var.