### PR TITLE
fix: Clean up release-please configs after some experimentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
               env:
                   HUSKY: 0 # Disable husky within CI/CD
             - uses: googleapis/release-please-action@v4
+              id: release
               with:
                   release-type: node
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,16 +1,3 @@
 {
-    ".": "1.1.7",
-    "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance Improvements" },
-        { "type": "revert", "section": "Reverts" },
-        { "type": "chore", "section": "Miscellaneous Chores" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "style", "section": "Styles" },
-        { "type": "refactor", "section": "Code Refactoring" },
-        { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "build", "section": "Build System", "hidden": true },
-        { "type": "ci", "section": "Continuous Integration", "hidden": true }
-    ]
+    ".": "1.1.6"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,26 @@
 {
-  "packages": {
-    ".": {
-      "changelog-path": "CHANGELOG.md",
-      "release-type": "node",
-      "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": false
-    }
-  },
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+    "packages": {
+        ".": {
+            "changelog-path": "CHANGELOG.md",
+            "release-type": "node",
+            "bump-minor-pre-major": false,
+            "bump-patch-for-minor-pre-major": false,
+            "draft": false,
+            "prerelease": false,
+            "changelog-sections": [
+                { "type": "feat", "section": "Features" },
+                { "type": "fix", "section": "Bug Fixes" },
+                { "type": "perf", "section": "Performance Improvements" },
+                { "type": "revert", "section": "Reverts" },
+                { "type": "chore", "section": "Miscellaneous Chores" },
+                { "type": "docs", "section": "Documentation" },
+                { "type": "style", "section": "Styles" },
+                { "type": "refactor", "section": "Code Refactoring" },
+                { "type": "test", "section": "Tests", "hidden": true },
+                { "type": "build", "section": "Build System", "hidden": true },
+                { "type": "ci", "section": "Continuous Integration", "hidden": true }
+            ]
+        }
+    },
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
My latest research shows there is simply no way to force release-please to cut a release, except via `feat` and `fix` commits. As such, all previous attempts to get release-please to act differently have failed, and we'll have to use `fix` for dependency updates going forward.

Trying that now with this branch!